### PR TITLE
Reverttoace1

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -12,11 +12,7 @@ DONE:
 <!DOCTYPE html>
 <html>
 <head>
-<!-- Why did git put "HEAD" and "upstream/master" in here? -->
-<!-- <<<<<<< HEAD
-======= -->
 	<link href="styles.css" rel="stylesheet" type="text/css" />
-<!-- >>>>>>> upstream/master -->
 	<title>qromp</title>
 	<!-- knod: I suggest a different title, something more descriptive -->
 	<!-- Quantum computer simulator and reference -->
@@ -30,11 +26,11 @@ DONE:
 	 --><div id="menuContainer">
 		  	<div id="menu">
 		  		<!-- knod: A home button? -->
-			  	<div><a href="index.html">simulator</a></div><!--
-			 --><div><a href="help.html">help</a></div><!--
-			 --><div><a href="examples.html">examples</a></div><!--
-			 --><div><a href="lessons.html">lessons</a></div><!--
-			 --><div><a href="about.html">about</a></div>
+			  	<div><a>simulator</a></div><!--
+			 --><div><a>help</a></div><!--
+			 --><div><a>examples</a></div><!--
+			 --><div><a>lessons</a></div><!--
+			 --><div><a>about</a></div>
 		  	</div>
 	  	</div>
   	</div>
@@ -43,26 +39,14 @@ DONE:
 	  		<div id="visualizer">
 	  			<div id="visualizer-buffer">
 		  			<div id="qubitElements"></div>
-		  			<span id="numQubits">Number of qubits: <input id="qubitsInput" min="1" max="20" value="1" type="number"></span>
+		  			<span id="numQubits">Number of qubits: <input id="qubitsInput" min="1" max="9" value="1" type="number"></span>
 		  		</div>
 	  		</div>
-	  	 	<div id="editor">
-	  			<div id="scrollable-area">
-			  		<div id="textInput">
-	  					<div id="num-gutter"></div>
-			  			<div id="row-num-col">
-			  				<!-- To be filled dynamically later -->
-			  			</div>
-			  			<div id="text-areas">
-			  				<!-- To be filled dynamically later -->
-			  			</div>
-			  	 	</div>
-			  		<div id="reference">[tbd]</div>
-			  	</div>
-			  	<div id="editor-footer">
-		  	 		<button id="evaluate">Evaluate</button>
-		  	 	</div>
-			</div>
+	  	 	<div style="position:relative;" id="editor">
+		  		<div id="reference"></div><!--
+		  	 --><div id="ace"></div><!--
+		  	 --><button id="evaluate" style="position: absolute; bottom: 0; right: 0; z-index: 10; border: 0; cursor: pointer;">Evaluate</button>
+		  	</div>
 		</div>
 		<div id="diagram">
 			Examples (best place for now?):
@@ -83,10 +67,10 @@ Will experiment more later. This is what happens without
 enclosures! Bah! -->
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script type="text/javascript" src="http:////cdnjs.cloudflare.com/ajax/libs/Chart.js/0.2.0/Chart.min.js"></script>
-<script type="text/javascript" src="texteditor.js"></script>
-<!-- <script type="text/javascript" src="http://cdn.jsdelivr.net/ace/1.1.01/min/ace.js" charset="utf-8"></script> -->
+<script type="text/javascript" src="http://cdn.jsdelivr.net/ace/1.1.01/min/ace.js" charset="utf-8"></script>
+<!-- <script type="text/javascript" src="texteditor.js"></script> -->
 <script type="text/javascript" src="setup.js"></script>
 <script type="text/javascript" src="http:////cdnjs.cloudflare.com/ajax/libs/mathjs/0.18.1/math.min.js"></script>
-<script type="text/javascript" src="qrompsimple.js"></script>
+<script type="text/javascript" src="qromp.js"></script>
 <script type="text/javascript" src="visualizer.js"></script>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,6 @@ enclosures! Bah! -->
 <!-- <script type="text/javascript" src="texteditor.js"></script> -->
 <script type="text/javascript" src="setup.js"></script>
 <script type="text/javascript" src="http:////cdnjs.cloudflare.com/ajax/libs/mathjs/0.18.1/math.min.js"></script>
-<script type="text/javascript" src="qromp.js"></script>
+<script type="text/javascript" src="qrompsimple.js"></script>
 <script type="text/javascript" src="visualizer.js"></script>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -42,10 +42,12 @@ DONE:
 		  			<span id="numQubits">Number of qubits: <input id="qubitsInput" min="1" max="9" value="1" type="number"></span>
 		  		</div>
 	  		</div>
-	  	 	<div style="position:relative;" id="editor">
-		  		<div id="reference"></div><!--
-		  	 --><div id="ace"></div><!--
-		  	 --><button id="evaluate" style="position: absolute; bottom: 0; right: 0; z-index: 10; border: 0; cursor: pointer;">Evaluate</button>
+	  	 	<div id="editor">
+		  		<div id="reference">tbd</div><!--
+		  		--><div id="ace"></div><!--
+		  		--><div id="editor-footer">
+		  			<button id="evaluate">Evaluate</button>
+		  		</div>
 		  	</div>
 		</div>
 		<div id="diagram">

--- a/static/setup.js
+++ b/static/setup.js
@@ -19,37 +19,9 @@
 * 
 * ---	Visualizer	---
 * 
-* ---	Editor		---
-* - Should text editor key functions be called on
-* keypress instead in case they hold a key down?
-* - Perhaps keydown or key up should
-* $("#evaluate").trigger("click"); but onl if that
-* wont' result in an error
-* 
 * DONE:
-* - [DONE] Resize textarea's on window reszie
-* - [NOPE] qubitAttr - misspelled?
-* - [DONE] Decouple ace
 * 
 */
-
-// ORIGINAL, ACE (fourth line down) :
-// *** ? *** \\
-// GLOBAL VARS
-// And another five bite the dust
-var evaluate = document.getElementById("evaluate"),
-	$qubitsInput = $("#qubitsInput"),
-	$qubitElements = $("#qubitElements"),
-	editor = ace.edit("ace"),
-	qubits = [],
-	defaultQubit = {DOWN: {phase: 0, prob: 0}, UP: {phase: 0, prob: 1}},
-	qubitAttr;
-
-// knod's editor
-// Another global, to match the current generated js
-// var editor = {
-// 		getValue: function () {return(textEditor.getAllText($("#editor")));}
-// 	};
 
 // Elements requested before document ready may not
 // always be found, but I see that you wanted global
@@ -63,41 +35,29 @@ var evaluate = document.getElementById("evaluate"),
 // function or something if they're not used in
 // other scripts
 
-$(document).ready(function() {
+// *** SETUP *** \\
+// --- Visualizer? --- \\
+// - Global vars - \\
+// evaluate must be a DOM object, not a $ collection
+var evaluate = document.getElementById("evaluate"),
+	$qubitsInput = $("#qubitsInput"),
+	$qubitElements = $("#qubitElements"),
+	editor = ace.edit("ace"),
+	qubits = [],
+	defaultQubit = {DOWN: {phase: 0, prob: 0}, UP: {phase: 0, prob: 1}},
+	qubitAttr;
 
-	// ORIGINAL, ACE, ETC:
-	// *** VISULIZER *** \\
+$(document).ready(function() {
+	// *** SETUP ***\\
+
+	// --- Visualizer --- \\
 	positionQubits($qubitsInput.val());
 	editor.getSession().setUseWrapMode(true);
 
-	// *** ? *** \\
-	// Didn't bite the dust in here!!
+	// *** EVENT LISTENERS ***\\
+
+	// Display the images for the changed number of qubits
 	$qubitsInput.change(function() {
 		positionQubits($qubitsInput.val());
 	});
-
-	// // KNOD:
-	// // *** TEXT EDITOR *** \\
-
-	// // Create the first editor row
-	// textEditor.firstRow();
-
-	// $("#text-areas")
-	// // *Has* to be .on, *has* to be delegation
-	// // Make a tutorial about that somewhere
-	// // Depending on what key is pressed in a .text-row field
-	// .on("keydown", ".text-row", function (key) {
-	// 	textEditor.keyFilter(key, key.keyCode, $(this));
-	// })
-	// // Helps a bit withresizing after deleting section or
-	// // pasting, esp with clicking out of the area after
-	// .on("keyup", ".text-row", function (key) {textEditor.resizeRow($(this));})
-	// // Color the focused row the active colors
-	// .on("focus", ".text-row", function () {textEditor.activateRow($(this));})
-	// // Remove the color from the unfocused rows. Look
-	// // into keeping last active row colored when none are active
-	// .on("blur", ".text-row", function () {textEditor.deactivateRow($(this));})
-	// ;
-
-	// $(window).on("resize", function (key) {textEditor.resizeRow($(".text-row"));});
 });

--- a/static/setup.js
+++ b/static/setup.js
@@ -27,6 +27,7 @@
 * wont' result in an error
 * 
 * DONE:
+* - [DONE] Resize textarea's on window reszie
 * - [NOPE] qubitAttr - misspelled?
 * - [DONE] Decouple ace
 * 
@@ -39,15 +40,16 @@
 var evaluate = document.getElementById("evaluate"),
 	$qubitsInput = $("#qubitsInput"),
 	$qubitElements = $("#qubitElements"),
-	// editor = ace.edit("ace"),
+	editor = ace.edit("ace"),
 	qubits = [],
 	defaultQubit = {DOWN: {phase: 0, prob: 0}, UP: {phase: 0, prob: 1}},
 	qubitAttr;
 
+// knod's editor
 // Another global, to match the current generated js
-var editor = {
-		getValue: function () {return(textEditor.getAllText($("#editor")));}
-	};
+// var editor = {
+// 		getValue: function () {return(textEditor.getAllText($("#editor")));}
+// 	};
 
 // Elements requested before document ready may not
 // always be found, but I see that you wanted global
@@ -60,12 +62,13 @@ var editor = {
 // I can do it another way with an initializing
 // function or something if they're not used in
 // other scripts
+
 $(document).ready(function() {
 
 	// ORIGINAL, ACE, ETC:
 	// *** VISULIZER *** \\
 	positionQubits($qubitsInput.val());
-	// editor.getSession().setUseWrapMode(true);
+	editor.getSession().setUseWrapMode(true);
 
 	// *** ? *** \\
 	// Didn't bite the dust in here!!
@@ -73,35 +76,28 @@ $(document).ready(function() {
 		positionQubits($qubitsInput.val());
 	});
 
-	// KNOD:
-	// *** TEXT EDITOR *** \\
-	// Create the first editor row
-	textEditor.firstRow();
+	// // KNOD:
+	// // *** TEXT EDITOR *** \\
 
-	// *Has* to be .on, *has* to be delegation
-	// Make a tutorial about that somewhere
-	// Depending on what key is pressed in an input field
-	$("#text-areas")
-	.on("keydown", ".text-row", function (key) {
+	// // Create the first editor row
+	// textEditor.firstRow();
 
-		// Identify this .text-row
-		var $this = $(this);
-		// Affect input fields
-		textEditor.keyFilter(key, $this);
-	})
-	.on("keyup", ".text-row", function (key) {
-		// Helps resizing after deleting section or pasting,
-		// esp with clicking out of the area after
-		// Not completely though
-		textEditor.resizeRow($(this));
-	})
-	.on("focus", ".text-row", function () {
-		// Color the focused row the active colors
-		textEditor.activateRow($(this));
-	})
-	.on("blur", ".text-row", function () {
-		// Remove the color from the unfocused rows
-		textEditor.deactivateRow($(this));
-	})
-	;
+	// $("#text-areas")
+	// // *Has* to be .on, *has* to be delegation
+	// // Make a tutorial about that somewhere
+	// // Depending on what key is pressed in a .text-row field
+	// .on("keydown", ".text-row", function (key) {
+	// 	textEditor.keyFilter(key, key.keyCode, $(this));
+	// })
+	// // Helps a bit withresizing after deleting section or
+	// // pasting, esp with clicking out of the area after
+	// .on("keyup", ".text-row", function (key) {textEditor.resizeRow($(this));})
+	// // Color the focused row the active colors
+	// .on("focus", ".text-row", function () {textEditor.activateRow($(this));})
+	// // Remove the color from the unfocused rows. Look
+	// // into keeping last active row colored when none are active
+	// .on("blur", ".text-row", function () {textEditor.deactivateRow($(this));})
+	// ;
+
+	// $(window).on("resize", function (key) {textEditor.resizeRow($(".text-row"));});
 });

--- a/static/styles.css
+++ b/static/styles.css
@@ -9,13 +9,13 @@
 * 3. http://stackoverflow.com/questions/10487292/position-absolute-but-relative-to-parent
 * 
 * ToDo:
-* - #reference doesn't stay put on scrolling, attach to
-* non-scrolling parent.
-* - Figure out how to stack #scrollable-area on top of eval
+* - Figure out how to stack #ace on top of eval
 * button without resorting to hard pixels. Table?
 * - Should we do box-sizing for all textareas?
 * 
 * DONE:
+* - [DONE] #reference doesn't stay put on scrolling, attach to
+* non-scrolling parent.
 * 
 */
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -63,9 +63,9 @@ a:hover {
 	font-size: 5em;
 }
 
-/*#title a:hover {
+#title a:hover {
 	border: none;
-}*/
+}
 
 #tagline {
 	padding-left: .5em;

--- a/static/styles.css
+++ b/static/styles.css
@@ -63,9 +63,9 @@ a:hover {
 	font-size: 5em;
 }
 
-#title a:hover {
+/*#title a:hover {
 	border: none;
-}
+}*/
 
 #tagline {
 	padding-left: .5em;
@@ -99,7 +99,10 @@ a:hover {
 }
 
 /*--- Editor ---*/
+
+/* ace editor: */
 #editor {
+	position: relative; /* Puts #reference in the right place */
 	overflow: hidden;
 	border: 1px solid #dddddd;
 	/* Is box-sizing needed? */
@@ -108,89 +111,119 @@ a:hover {
 	box-sizing: border-box;         /* Opera/IE 8+ */
 }
 
-#scrollable-area {
-	/* em means on cmd+ eval button still has room, I think */
-	/* Nope, percent worked just as well */
-	height: 43.6em; /* Space left for evaluate at bottom */
-	overflow: auto;
-	/* Puts #reference in the right place */
-	/* See #qubitElements notes */
-	position: relative;
-}
+		/* for knod's editor: */
+		/*#editor {
+			overflow: hidden;
+			border: 1px solid #dddddd;
+			/* Is box-sizing needed? */
+			/*-webkit-box-sizing: border-box;*/ /* Safari/Chrome, other WebKit */
+			/*-moz-box-sizing: border-box;*/    /* Firefox, other Gecko */
+			/*box-sizing: border-box;*/         /* Opera/IE 8+ */
+		/*}*/
 
-#textInput {
-	position: relative; /* Without this, #num-gutter extends to bottom (why?)*/
-	width: 100%;
-	/*border-bottom: 1px solid #dddddd;*/
-	overflow: hidden;
-	min-height: 100%;
-}
+		#scrollable-area {
+			/* em means on cmd+ eval button still has room, I think */
+			/* Nope, percent worked just as well */
+			height: 43.6em; /* Space left for evaluate at bottom */
+			overflow: auto;
+			/* Puts #reference in the right place */
+			/* See #qubitElements notes */
+			position: relative;}
 
-#textInput>div {
-	font-size: 15px;
-}
+		#textInput {
+			position: relative; /* Without this, #num-gutter extends to bottom (why?)*/
+			width: 100%;
+			/*border-bottom: 1px solid #dddddd;*/
+			overflow: hidden;
+			min-height: 100%;
+		}
 
-#num-gutter {
-	position: absolute;
-	left: 0;
-	top: 0;
-	width: 22px; /*Must be same as #row-num-col*/
-	height: 100%;
-	background: #f0f0f0;
-	z-index: -1; /*Somehow this works even though sibs have no position:absolute*/
-}
+		#textInput>div {
+			font-size: 15px;
+		}
 
-#row-num-col {
-	width: 22px; /*Must be same as #num-gutter*/
-	float: left;
-}
+		#num-gutter {
+			position: absolute;
+			left: 0;
+			top: 0;
+			width: 22px; /*Must be same as #row-num-col*/
+			height: 100%;
+			background: #f0f0f0;
+			z-index: -1; /*Somehow this works even though sibs have no position:absolute*/
+		}
 
-#text-areas {
-	overflow: hidden;
-}
+		#row-num-col {
+			width: 22px; /*Must be same as #num-gutter*/
+			float: left;
+		}
 
-.num-row {
-	text-align: right;
-	padding: 1px 4px 1px 0;
-}
+		#text-areas {
+			overflow: hidden;
+		}
 
-/* .text-row's are textareas */
-.text-row {
-	outline: none;
-	display: block;
-	padding: 1px 6px;
-	width: 100%;
-	font-size: 15px;
-	border: none;
-	resize: none;
-	/* Maybe we should make this for all textareas. Will there be others? */
-	/* Sources (2) */
-	-webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
-	-moz-box-sizing: border-box;    /* Firefox, other Gecko */
-	box-sizing: border-box;         /* Opera/IE 8+ */
-}
+		.num-row {
+			text-align: right;
+			padding: 1px 4px 1px 0;
+		}
 
+		/* .text-row's are textareas */
+		.text-row {
+			outline: none;
+			display: block;
+			padding: 1px 6px;
+			width: 100%;
+			font-size: 15px;
+			border: none;
+			resize: none;
+			/* Maybe we should make this for all textareas. Will there be others? */
+			/* Sources (2) */
+			-webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+			-moz-box-sizing: border-box;    /* Firefox, other Gecko */
+			box-sizing: border-box;         /* Opera/IE 8+ */
+		}
+
+/* ace reference: */
 #reference {
 	position: absolute;
 	right: 0;
 	top: 0;
+	z-index: 100;
 }
 
+			/* knod's reference: */
+			/*#reference {
+				position: absolute;
+				right: 0;
+				top: 0;
+			}*/
+
+/*--- Ace ---*/
+#ace {
+	height: 436px; /* Space left for evaluate at bottom */
+	/* See #qubitElements notes in #visualizer-buffer */
+	position: relative;
+	width: 100%;
+	/*border-bottom: 1px solid #dddddd;*/
+	overflow: scroll;
+}
+
+.ace_gutter-cell {
+	padding-left: .6em !important;
+	padding-right: .6em !important;
+}
+
+/*--- Editor footer ---*/
 #editor-footer {
 	text-align: right;
 	width: 100%;
 }
 
+/*evaluate inline style="position: absolute; bottom: 0;
+right: 0; z-index: 10; border: 0; cursor: pointer;"*/
 #evaluate {
 	position:relative;
 	border: 0;
 	cursor: pointer;
-}
-
-#ace {
-	overflow: hidden;
-	height: 100%;
-	width: 100%;
 }
 
 /*--- Visualizer ---*/
@@ -260,11 +293,4 @@ canvas {
 	-webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
 	-moz-box-sizing: border-box;    /* Firefox, other Gecko */
 	box-sizing: border-box;         /* Opera/IE 8+ */
-}
-
-/*--- ACE ---*/
-
-.ace_gutter-cell {
-	padding-left: .6em !important;
-	padding-right: .6em !important;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -187,11 +187,11 @@ a:hover {
 	cursor: pointer;
 }
 
-/*#ace {
+#ace {
 	overflow: hidden;
 	height: 100%;
 	width: 100%;
-}*/
+}
 
 /*--- Visualizer ---*/
 #visualizer {
@@ -263,7 +263,7 @@ canvas {
 }
 
 /*--- ACE ---*/
-/*
+
 .ace_gutter-cell {
 	padding-left: .6em !important;
 	padding-right: .6em !important;

--- a/static/texteditor.js
+++ b/static/texteditor.js
@@ -22,6 +22,11 @@
 * blank for the evaluate button?
 * - Make cursor re-focus on last position in editor after
 * "Evaluate" has been pressed.
+* - Should text editor key functions be called on
+* keypress instead in case they hold a key down?
+* - Perhaps keydown or key up should
+* $("#evaluate").trigger("click"); but onl if that
+* wont' result in an error
 * 
 * DONE:
 * - [DONE] Fix #1 Cannot delete linebreak for non-blank lines
@@ -33,6 +38,41 @@
 * 
 */
 
+// // knod's editor
+// // Another global, to match the current generated js
+// var editor = {
+// 		getValue: function () {return(textEditor.getAllText($("#editor")));}
+// 	};
+
+// $(document).ready(function() {
+// 	// *** SETUP ***\\
+// 	// *** TEXT EDITOR *** \\
+// 	// Create the first editor row
+// 	textEditor.firstRow();
+
+// 	// *** EVENT LISTENERS ***\\
+// 	$("#text-areas")
+// 	// *Has* to be .on, *has* to be delegation
+// 	// Make a tutorial about that somewhere
+// 	// Depending on what key is pressed in a .text-row field
+// 	.on("keydown", ".text-row", function (key) {
+// 		textEditor.keyFilter(key, key.keyCode, $(this));
+// 	})
+// 	// Helps a bit withresizing after deleting section or
+// 	// pasting, esp with clicking out of the area after
+// 	.on("keyup", ".text-row", function (key) {textEditor.resizeRow($(this));})
+// 	// Color the focused row the active colors
+// 	.on("focus", ".text-row", function () {textEditor.activateRow($(this));})
+// 	// Remove the color from the unfocused rows. Look
+// 	// into keeping last active row colored when none are active
+// 	.on("blur", ".text-row", function () {textEditor.deactivateRow($(this));})
+// 	;
+
+// 	$(window).on("resize", function (key) {textEditor.resizeRow($(".text-row"));});
+// });
+
+// *** OPERATIONAL *** \\
+// Enclosure for texteditor functions
 var textEditor = {
 	/* Enclosure for text editor functions */
 


### PR DESCRIPTION
- Taking out the custom text editor for now and reverting to the ace editor.
- Uses qrompsimple.js now, the qromp.cljs compiled with :simple.
- qubit input limit reduced to 9 because... come on. We can discuss.
- Custom text editor stuff moved to texteditor.js so it's there but doesn't make things messy
- Custom text editor styles are still there. Those that had to be marked out were marked out and they were all indented significantly. They may get in the way. We can either put them in a different file later if we want to keep them around or just get rid of them and retrieve them from old commits if we need to.
- Some style changes stuck around to take advantage of advances made during the making of this detour.
