### PR TITLE
Panels2 jQuery UI added, slides work, scroller div gone

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,130 +13,129 @@
 </head>
 <body>
 	<div id="header-back"></div>
-	<div> <!-- id="scroller"> -->
-		<main><div class='main-container'>
-			<div id="header">
-				<div id="banner">
-					<span id="title">qromp</span>
-					<span id="tagline">learnable quantum programming</span>
-				</div><!--		
-		 --><div id="header-menu">
-					<input type="file" id="hidden-file-input"/>
-					<span class="button" id="export">export</span>
-					<span class="button" id="import">import</span>
-					<span class="button" id="about">about</span>
+	<main><div class='main-container'>
+		<div id="header">
+			<div id="banner">
+				<span id="title">qromp</span>
+				<span id="tagline">learnable quantum programming</span>
+			</div><!--		
+	 --><div id="header-menu">
+				<input type="file" id="hidden-file-input"/>
+				<span class="button" id="export">export</span>
+				<span class="button" id="import">import</span>
+				<span class="button" id="about">about</span>
+			</div>
+		</div>
+		<div class='panel panel-app'>
+			<div id="app">
+		  		<div id="editor">
+		  	 		<div id="reference">
+			  	 		<div id="reference-content">
+				  	 		<h3>reference</h3>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				qnot <i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				cnot <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				srn <i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				nand <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				hadamard <i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				utheta <i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				cphase <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				u2 <i class="icon icon-qubit"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				swap <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				measure <i class="icon icon-qubit"></i>
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				end
+				  	 			</div>
+				  	 		</div>
+				  	 		<div class="reference-line">
+				  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+				  	 				oracle <i class="icon icon-qubit"></i>...
+				  	 			</div>
+				  	 		</div>
+			  	 		</div>
+			  	 	 	<div class="button" id="reference-handle"><i class="icon icon-arrow"></i></div>
+		  	 		</div>
+		  	 	 	<div id="code-area"></div>
+		  	 	</div><!-- 
+		  	 --><div id="visualizer">
+		  			<div id="visualizer-buffer">
+			  			<span id="num-qubits">qubits</span>
+			  			<div class="button" id="remove-qubit">-</div>
+			  			<div class="button" id="add-qubit">+</div>
+			  		</div>
+			  		<svg id="qubit-svg" width="100%" height="100%"></svg>
+		  		</div>
+				<div id="diagram">
+					<div id="parts-bin"></div>
+					<div id="circuit"></div>
 				</div>
 			</div>
-			<div class='panel panel-app'>
-				<div id="app">
-			  		<div id="editor">
-			  	 		<div id="reference">
-				  	 		<div id="reference-content">
-					  	 		<h3>reference</h3>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				qnot <i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				cnot <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				srn <i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				nand <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				hadamard <i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				utheta <i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				cphase <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				u2 <i class="icon icon-qubit"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				swap <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				measure <i class="icon icon-qubit"></i>
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				end
-					  	 			</div>
-					  	 		</div>
-					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
-					  	 				oracle <i class="icon icon-qubit"></i>...
-					  	 			</div>
-					  	 		</div>
-				  	 		</div>
-				  	 	 	<div class="button" id="reference-handle"><i class="icon icon-arrow"></i></div>
-			  	 		</div>
-			  	 	 	<div id="code-area"></div>
-			  	 	</div><!-- 
-			  	 --><div id="visualizer">
-			  			<div id="visualizer-buffer">
-				  			<span id="num-qubits">qubits</span>
-				  			<div class="button" id="remove-qubit">-</div>
-				  			<div class="button" id="add-qubit">+</div>
-				  		</div>
-				  		<svg id="qubit-svg" width="100%" height="100%"></svg>
-			  		</div>
-					<div id="diagram">
-						<div id="parts-bin"></div>
-						<div id="circuit"></div>
-					</div>
+			<div id="guide">
+				<div id="guide-menu">
+					<h1>lessons</h1>
+					<a class="guide-link button" data-target="#l-start">getting started</a>
+					<a class="guide-link button" data-target="#l-quantum-computers">on quantum computers</a>
+					<a class="guide-link button" data-target="#l-qubits">on qubits</a>
+					<a class="guide-link button" data-target="#l-gates">on quantum gates</a>
+					<a class="guide-link button" data-target="#l-oracles">on oracles</a>
+					<a class="guide-link button" data-target="#l-grovers">Grover's algorithm</a>
+					<h1>examples</h1>
+					<a class="guide-link button" data-target="#e-deutsch-jozsa">Deutsch-Jozsa algorithm</a>
+					<a class="guide-link button" data-target="#e-grovers">Grover's algorithm</a>
+					<a class="guide-link button" data-target="#e-shors">Shor's algorithm</a>
 				</div>
-				<div id="guide">
-					<div id="guide-menu">
-						<h1>lessons</h1>
-						<a class="guide-link button" data-target="#l-start">getting started</a>
-						<a class="guide-link button" data-target="#l-quantum-computers">on quantum computers</a>
-						<a class="guide-link button" data-target="#l-qubits">on qubits</a>
-						<a class="guide-link button" data-target="#l-gates">on quantum gates</a>
-						<a class="guide-link button" data-target="#l-oracles">on oracles</a>
-						<a class="guide-link button" data-target="#l-grovers">Grover's algorithm</a>
-						<h1>examples</h1>
-						<a class="guide-link button" data-target="#e-deutsch-jozsa">Deutsch-Jozsa algorithm</a>
-						<a class="guide-link button" data-target="#e-grovers">Grover's algorithm</a>
-						<a class="guide-link button" data-target="#e-shors">Shor's algorithm</a>
-					</div>
-					<div class="hidden" id="guide-detail">
-						<a class="button" id="guide-back"><i class="icon icon-arrow flip-h"></i> lessons & examples</a>
-						<h2 id="guide-item-title">getting started</h2>
-						<div class="guide-item" id="l-start">
-							Welcome to qromp, a quantum programming environment designed to help you learn all about stuff...
-							<div class='example-list'>
-							Click on an example (feature incomplete):
-								<ul>
-									<li class='example'>u2 0 1 0.3 1.6 1</li>
-									<li class='example'>hadamard 0</li>
-									<li class='example'>utheta 0 0.6</li>
-									<li class='example'>hadamard 2<br>
+				<div class="hidden" id="guide-detail">
+					<a class="button" id="guide-back"><i class="icon icon-arrow flip-h"></i> lessons & examples</a>
+					<h2 id="guide-item-title">getting started</h2>
+					<div class="guide-item" id="l-start">
+						Welcome to qromp, a quantum programming environment designed to help you learn all about stuff...
+						<div class='example-list'>
+						Click on an example (feature incomplete):
+							<ul>
+								<li class='example'>u2 0 1 0.3 1.6 1</li>
+								<li class='example'>hadamard 0</li>
+								<li class='example'>utheta 0 0.6</li>
+								<li class='example'>hadamard 2<br>
 hadamard 1<br>
 utheta 0 0.785398<br>
 nand 0 2 1<br>
@@ -145,17 +144,16 @@ cnot 2 1<br>
 hadamard 2<br>
 utheta 1 1.570796<br>
 utheta 2 1.570796</li>
-								</ul>
-							</div>
+							</ul>
 						</div>
 					</div>
 				</div>
 			</div>
-			<div class='panel panel-about panel-right'>
-				(About)
-			</div>
-		</div></main>
-	</div>
+		</div>
+		<div class='panel panel-about panel-right'>
+			(About)
+		</div>
+	</div></main>
 	<script src="visualizer.js"></script>
 	<script src="qromp.js"></script>
 	<script src="setup.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,7 @@
 	<script src="http://cdn.jsdelivr.net/ace/1.1.01/min/ace.js" charset="utf-8"></script>
 	<script src="http://cdnjs.cloudflare.com/ajax/libs/mathjs/0.18.1/math.min.js"></script>
 	<script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+	<script src="http://code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
 	<script src="panels.js"></script>
 	<title>qromp - learnable quantum programming</title>
 </head>

--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 	<div id="header-back"></div>
-	<div id="scroller">
+	<div> <!-- id="scroller"> -->
 		<main><div class='main-container'>
 			<div id="header">
 				<div id="banner">
@@ -150,9 +150,9 @@ utheta 2 1.570796</li>
 					</div>
 				</div>
 			</div>
-			<span class='panel panel-about panel-right'>
+			<div class='panel panel-about panel-right'>
 				(About)
-			</span>
+			</div>
 		</div></main>
 	</div>
 	<script src="visualizer.js"></script>

--- a/static/panels.js
+++ b/static/panels.js
@@ -4,6 +4,7 @@
 * Getting between the "about" section and the simulator section
 * 
 * Sources:
+* 1. http://jsfiddle.net/QDUQk/1/
 * 
 * TODO:
 *
@@ -14,6 +15,7 @@
 $(document).ready(function() {
 	// --- SETUP --- \\
 	var slideTime = 600, simShowing = true, canToggle = true;
+	// $(".panel-about").toggle('slide', {direction: 'right'}, 0);
 
 	// --- FUNCTIONS --- \\
 	var togglePanes = function () {
@@ -23,33 +25,42 @@ $(document).ready(function() {
 		Hides .panel-about when it's not visible.
 		*/
 
-		if (canToggle) {
-			// Don't allow more panel toggling till this one is done
-			canToggle = false;
+		// Sources (1)
+		// if($(".panel-app").is(':visible')){
+			$(".panel-app").toggle('slide', {direction: 'left'}, slideTime);
+		// }
 
-			if (simShowing) {
-				$(".panel-app").css({"left": "calc(-100% - 2em)", width: "0"});
-				$(".panel-about").css({"left": "0", width: "100%"});
-				simShowing = false;
-			}
+		// if($(".panel-about").is(':visible')){
+			$(".panel-about").toggle('slide', {direction: 'right'}, slideTime);
+		// }
 
-			else {
-				$(".panel-app").css({"left": "0", width: "100%"});
-				$(".panel-about").css({"left": "calc(100% + 2em)", width: "0"});
-				simShowing = true;
-			}
+		// if (canToggle) {
+		// 	// Don't allow more panel toggling till this one is done
+		// 	canToggle = false;
 
-			// $(".panel-app").toggleClass("panel-left");
-			// $(".panel-about").toggleClass("panel-center")
+		// 	if (simShowing) {
+		// 		$(".panel-app").css({"left": "calc(-100% - 2em)", width: "0"});
+		// 		$(".panel-about").css({"left": "0", width: "100%"});
+		// 		simShowing = false;
+		// 	}
 
-			// // Toggle simShowing (for showSim to an unneeded animation)
-			// if ($(".panel-app").hasClass("panel-left")) {
-			// 	simShowing = false;
-			// }
-			// else {simShowing = true;}
+		// 	else {
+		// 		$(".panel-app").css({"left": "0", width: "100%"});
+		// 		$(".panel-about").css({"left": "calc(100% + 2em)", width: "0"});
+		// 		simShowing = true;
+		// 	}
 
-			canToggle = true;
-		}
+		// 	// $(".panel-app").toggleClass("panel-left");
+		// 	// $(".panel-about").toggleClass("panel-center")
+
+		// 	// // Toggle simShowing (for showSim to an unneeded animation)
+		// 	// if ($(".panel-app").hasClass("panel-left")) {
+		// 	// 	simShowing = false;
+		// 	// }
+		// 	// else {simShowing = true;}
+
+		// 	canToggle = true;
+		// }
 	};
 
 	var showSim = function () {

--- a/static/panels.js
+++ b/static/panels.js
@@ -14,53 +14,22 @@
 
 $(document).ready(function() {
 	// --- SETUP --- \\
-	var slideTime = 600, simShowing = true, canToggle = true;
-	// $(".panel-about").toggle('slide', {direction: 'right'}, 0);
+	var slideTime = 600, simShowing = true;
 
 	// --- FUNCTIONS --- \\
 	var togglePanes = function () {
 		/* (None) -> (None)
 
-		Runs a slide animation to toggle which .panel is visible.
-		Hides .panel-about when it's not visible.
+		Runs a slide animation to toggle which .panel displays.
 		*/
 
-		// Sources (1)
-		// if($(".panel-app").is(':visible')){
-			$(".panel-app").toggle('slide', {direction: 'left'}, slideTime);
-		// }
-
-		// if($(".panel-about").is(':visible')){
-			$(".panel-about").toggle('slide', {direction: 'right'}, slideTime);
-		// }
-
-		// if (canToggle) {
-		// 	// Don't allow more panel toggling till this one is done
-		// 	canToggle = false;
-
-		// 	if (simShowing) {
-		// 		$(".panel-app").css({"left": "calc(-100% - 2em)", width: "0"});
-		// 		$(".panel-about").css({"left": "0", width: "100%"});
-		// 		simShowing = false;
-		// 	}
-
-		// 	else {
-		// 		$(".panel-app").css({"left": "0", width: "100%"});
-		// 		$(".panel-about").css({"left": "calc(100% + 2em)", width: "0"});
-		// 		simShowing = true;
-		// 	}
-
-		// 	// $(".panel-app").toggleClass("panel-left");
-		// 	// $(".panel-about").toggleClass("panel-center")
-
-		// 	// // Toggle simShowing (for showSim to an unneeded animation)
-		// 	// if ($(".panel-app").hasClass("panel-left")) {
-		// 	// 	simShowing = false;
-		// 	// }
-		// 	// else {simShowing = true;}
-
-		// 	canToggle = true;
-		// }
+		// Sources (1) Uses jQuery UI to do a slide animation for both
+		$(".panel-app").toggle('slide', {direction: 'left'}, slideTime);
+		$(".panel-about").toggle('slide', {direction: 'right'}, slideTime, function () {
+			// If the simulator is visible, don't allow showSim() functions to run
+			if($(".panel-app").is(':visible')){simShowing = true;}
+			else {simShowing = false;}
+		});
 	};
 
 	var showSim = function () {
@@ -71,8 +40,8 @@ $(document).ready(function() {
 
 		// Only do an animation if the sim is hidden
 		if (!simShowing) {
-			$(".panel-app").removeClass("panel-left");
-			$(".panel-about").removeClass("panel-center");
+			$(".panel-app").toggle('slide', {direction: 'left'}, slideTime);
+			$(".panel-about").toggle('slide', {direction: 'right'}, slideTime);
 		}
 
 	};

--- a/static/panels.js
+++ b/static/panels.js
@@ -1,1 +1,75 @@
-panels.js
+/* panels.js
+* Created by: knod
+* Date: 04/10/14
+* Getting between the "about" section and the simulator section
+* 
+* Sources:
+* 
+* TODO:
+*
+* DONE:
+* 
+*/
+
+$(document).ready(function() {
+	// --- SETUP --- \\
+	var slideTime = 600, simShowing = true, canToggle = true;
+
+	// --- FUNCTIONS --- \\
+	var togglePanes = function () {
+		/* (None) -> (None)
+
+		Runs a slide animation to toggle which .panel is visible.
+		Hides .panel-about when it's not visible.
+		*/
+
+		if (canToggle) {
+			// Don't allow more panel toggling till this one is done
+			canToggle = false;
+
+			if (simShowing) {
+				$(".panel-app").css({"left": "calc(-100% - 2em)", width: "0"});
+				$(".panel-about").css({"left": "0", width: "100%"});
+				simShowing = false;
+			}
+
+			else {
+				$(".panel-app").css({"left": "0", width: "100%"});
+				$(".panel-about").css({"left": "calc(100% + 2em)", width: "0"});
+				simShowing = true;
+			}
+
+			// $(".panel-app").toggleClass("panel-left");
+			// $(".panel-about").toggleClass("panel-center")
+
+			// // Toggle simShowing (for showSim to an unneeded animation)
+			// if ($(".panel-app").hasClass("panel-left")) {
+			// 	simShowing = false;
+			// }
+			// else {simShowing = true;}
+
+			canToggle = true;
+		}
+	};
+
+	var showSim = function () {
+		/* (None) -> (None)
+
+		Makes sure the simulator is showing
+		*/
+
+		// Only do an animation if the sim is hidden
+		if (!simShowing) {
+			$(".panel-app").removeClass("panel-left");
+			$(".panel-about").removeClass("panel-center");
+		}
+
+	};
+
+	// --- EVENT LISTENERS --- \\
+	// This has to come after so that the functions called  here exist first
+
+	$("#about").on("click", togglePanes);
+	$("#title").on("click", showSim);
+
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -2,13 +2,6 @@ html{font-size:10px}body{font-family:'Helvetica', sans-serif;color:#424242;paddi
 
 /* Something is seriously wrong in this site. */
 
-main {
-	position: relative;
-	/*height: 100%;*/ /* Means everything would have to be height 100%*/
-	/*overflow-x: hidden;*/
-	/*overflow-y: visible;*/
-}
-
 .main-container {
 	position: relative;
 	width: 100%;
@@ -17,7 +10,8 @@ main {
 
 .panel {
 	position: absolute;
-	/*width: 100%;*/
+	left: 0;
+	width: 100%;
 	height: 100%;
 	margin-bottom: 1rem;
 	-webkit-box-sizing:border-box;
@@ -26,29 +20,9 @@ main {
 }
 
 .panel-app {
-	width: 100%;
-	left: 0;
-	transition: left .5s linear;
-	transition: width .5s linear;
 }
-
-/*.panel-left {
-	left: calc(-100% - 2em);
-}*/
 
 .panel-about {
-	display: inline;
-	width: 0;
-	left: calc(100% + 2em);
+	display: none;
 	background-color: lightblue;
-	transition: left .5s linear;
 }
-
-/*.panel-right {
-	left: calc(100% + 2em);
-}*/
-
-/*.panel-center {
-	left: 0;
-}*/
-

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,6 +6,7 @@ main {
 	position: relative;
 	/*height: 100%;*/ /* Means everything would have to be height 100%*/
 	/*overflow-x: hidden;*/
+	/*overflow-y: visible;*/
 }
 
 .main-container {
@@ -16,7 +17,7 @@ main {
 
 .panel {
 	position: absolute;
-	width: 100%;
+	/*width: 100%;*/
 	height: 100%;
 	margin-bottom: 1rem;
 	-webkit-box-sizing:border-box;
@@ -25,23 +26,29 @@ main {
 }
 
 .panel-app {
-
+	width: 100%;
+	left: 0;
+	transition: left .5s linear;
+	transition: width .5s linear;
 }
 
-.panel-left {
-	left: -110%;
-}
+/*.panel-left {
+	left: calc(-100% - 2em);
+}*/
 
 .panel-about {
-	display: hidden;
+	display: inline;
+	width: 0;
+	left: calc(100% + 2em);
 	background-color: lightblue;
+	transition: left .5s linear;
 }
 
-.panel-right {
-	left: 110%;
-}
+/*.panel-right {
+	left: calc(100% + 2em);
+}*/
 
-.panel-center {
+/*.panel-center {
 	left: 0;
-}
+}*/
 


### PR DESCRIPTION
jQuery UI makes the sliders work really really easily. It was unclear I'd be able to create that functionality myself without a lot more work.

Now the cosmetics of the about page need to be done, it's just blue and ugly for visibility right now. Feed me content!

Watch out for my .main-container div, I forgot to make it more explicitly visible. #scroller div is gone as it didn't seem to have any functionality other than scrolling the main content separately from everything else. It's css is still there so it can be added back in if needed.

Remember to remove #scroller css if we actually don't use it.

I'm not sure why the header is coming down with everything else, maybe that's what #scroller was doing, but it needs to be done differently.

The html needs some overhauling, stuff is very confused right now, and when things are more settled I'll do that too, but stuff is changing a lot so I've been holding off.
