### PR TITLE
Reftodocs - reference question marks will trigger the relevant documentation to appear

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -144,7 +144,7 @@
 						<a class="guide-link button d-oracle" data-target=".d-oracle">oracle</a>
 					</div>
 					<div class="hidden" id="guide-detail">
-						<a class="button" id="guide-back"><i class="icon icon-arrow flip-h"></i> lessons & examples</a>
+						<a class="button" id="guide-back"><i class="icon icon-arrow flip-h"></i> lessons, examples,  & documentation</a>
 						<h2 class="guide-item-title">getting started</h2>
 						<div class="guide-item l-start"></div>
 						<div class="guide-item l-quantcomp"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -39,62 +39,62 @@
 				  	 		<div id="reference-content">
 					  	 		<h3>reference</h3>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-qnot">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-qnot">&nbsp;?</div><div class="reference-item">
 					  	 				qnot <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-cnot">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-cnot">&nbsp;?</div><div class="reference-item">
 					  	 				cnot <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-srn">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-srn">&nbsp;?</div><div class="reference-item">
 					  	 				srn <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-nand">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-nand">&nbsp;?</div><div class="reference-item">
 					  	 				nand <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-hadamard">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-hadamard">&nbsp;?</div><div class="reference-item">
 					  	 				hadamard <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-utheta">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-utheta">&nbsp;?</div><div class="reference-item">
 					  	 				utheta <i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-cphase">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-cphase">&nbsp;?</div><div class="reference-item">
 					  	 				cphase <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-u2">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-u2">&nbsp;?</div><div class="reference-item">
 					  	 				u2 <i class="icon icon-qubit"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-swap">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-swap">&nbsp;?</div><div class="reference-item">
 					  	 				swap <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-measure">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-measure">&nbsp;?</div><div class="reference-item">
 					  	 				measure <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-end">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-end">&nbsp;?</div><div class="reference-item">
 					  	 				end
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button" data-target="#d-oracle">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target=".d-oracle">&nbsp;?</div><div class="reference-item">
 					  	 				oracle <i class="icon icon-qubit"></i>...
 					  	 			</div>
 					  	 		</div>
@@ -119,54 +119,54 @@
 				<div id="guide">
 					<div id="guide-menu">
 						<h1>lessons</h1>
-						<a class="guide-link button" data-target="#l-start">getting started</a>
-						<a class="guide-link button" data-target="#l-quant-comp">on quantum computers</a>
-						<a class="guide-link button" data-target="#l-qubits">on qubits</a>
-						<a class="guide-link button" data-target="#l-gates">on quantum gates</a>
-						<a class="guide-link button" data-target="#l-oracles">on oracles</a>
-						<a class="guide-link button" data-target="#l-grovers">Grover's algorithm</a>
+						<a class="guide-link button l-start" data-target=".l-start">getting started</a>
+						<a class="guide-link button l-quantcomp" data-target=".l-quantcomp">on quantum computers</a>
+						<a class="guide-link button l-qubits" data-target=".l-qubits">on qubits</a>
+						<a class="guide-link button l-gates" data-target=".l-gates">on quantum gates</a>
+						<a class="guide-link button l-oracles" data-target=".l-oracles">on oracles</a>
+						<a class="guide-link button l-grovers" data-target=".l-grovers">Grover's algorithm</a>
 						<h1>examples</h1>
-						<a class="guide-link button" data-target="#e-deutsch-jozsa">Deutsch-Jozsa algorithm</a>
-						<a class="guide-link button" data-target="#e-grovers">Grover's algorithm</a>
-						<a class="guide-link button" data-target="#e-shors">Shor's algorithm</a>
+						<a class="guide-link button e-deutschjozsa" data-target=".e-deutschjozsa">Deutsch-Jozsa algorithm</a>
+						<a class="guide-link button e-grovers" data-target=".e-grovers">Grover's algorithm</a>
+						<a class="guide-link button e-shors" data-target=".e-shors">Shor's algorithm</a>
 						<h1>documentation</h1>
-						<a class="guide-link button" data-target="#d-qnot">qnot</a>
-						<a class="guide-link button" data-target="#d-cnot">cnot</a>
-						<a class="guide-link button" data-target="#d-srn">srn</a>
-						<a class="guide-link button" data-target="#d-nand">nand</a>
-						<a class="guide-link button" data-target="#d-hadamard">hadamard</a>
-						<a class="guide-link button" data-target="#d-utheta">utheta</a>
-						<a class="guide-link button" data-target="#d-cphase">cphase</a>
-						<a class="guide-link button" data-target="#d-u2">u2</a>
-						<a class="guide-link button" data-target="#d-swap">swap</a>
-						<a class="guide-link button" data-target="#d-measure">measure</a>
-						<a class="guide-link button" data-target="#d-end">end</a>
-						<a class="guide-link button" data-target="#d-oracle">oracle</a>
+						<a class="guide-link button d-qnot" data-target=".d-qnot">qnot</a>
+						<a class="guide-link button d-cnot" data-target=".d-cnot">cnot</a>
+						<a class="guide-link button d-srn" data-target=".d-srn">srn</a>
+						<a class="guide-link button d-nand" data-target=".d-nand">nand</a>
+						<a class="guide-link button d-hadamard" data-target=".d-hadamard">hadamard</a>
+						<a class="guide-link button d-utheta" data-target=".d-utheta">utheta</a>
+						<a class="guide-link button d-cphase" data-target=".d-cphase">cphase</a>
+						<a class="guide-link button d-u2" data-target=".d-u2">u2</a>
+						<a class="guide-link button d-swap" data-target=".d-swap">swap</a>
+						<a class="guide-link button d-measure" data-target=".d-measure">measure</a>
+						<a class="guide-link button d-end" data-target=".d-end">end</a>
+						<a class="guide-link button d-oracle" data-target=".d-oracle">oracle</a>
 					</div>
 					<div class="hidden" id="guide-detail">
 						<a class="button" id="guide-back"><i class="icon icon-arrow flip-h"></i> lessons & examples</a>
-						<h2 id="guide-item-title">getting started</h2>
-						<div class="guide-item" id="l-start">thing</div>
-						<div class="guide-item" id="l-quant-comp"></div>
-						<div class="guide-item" id="l-qubits"></div>
-						<div class="guide-item" id="l-gates"></div>
-						<div class="guide-item" id="l-oracles"></div>
-						<div class="guide-item" id="l-grovers"></div>
-						<div class="guide-item" id="e-deutsch-jozsa"></div>
-						<div class="guide-item" id="e-grovers"></div>
-						<div class="guide-item" id="e-shors"></div>
-						<div class="guide-item" id="d-qnot"></div>
-						<div class="guide-item" id="d-cnot"></div>
-						<div class="guide-item" id="d-srn"></div>
-						<div class="guide-item" id="d-nand"></div>
-						<div class="guide-item" id="d-hadamard"></div>
-						<div class="guide-item" id="d-utheta"></div>
-						<div class="guide-item" id="d-cphase"></div>
-						<div class="guide-item" id="d-u2"></div>
-						<div class="guide-item" id="d-swap"></div>
-						<div class="guide-item" id="d-measure"></div>
-						<div class="guide-item" id="d-end"></div>
-						<div class="guide-item" id="d-oracle"></div>
+						<h2 class="guide-item-title">getting started</h2>
+						<div class="guide-item l-start"></div>
+						<div class="guide-item l-quantcomp"></div>
+						<div class="guide-item l-qubits"></div>
+						<div class="guide-item l-gates"></div>
+						<div class="guide-item l-oracles"></div>
+						<div class="guide-item l-grovers"></div>
+						<div class="guide-item e-deutschjozsa"></div>
+						<div class="guide-item e-grovers"></div>
+						<div class="guide-item e-shors"></div>
+						<div class="guide-item d-qnot"></div>
+						<div class="guide-item d-cnot"></div>
+						<div class="guide-item d-srn"></div>
+						<div class="guide-item d-nand"></div>
+						<div class="guide-item d-hadamard"></div>
+						<div class="guide-item d-utheta"></div>
+						<div class="guide-item d-cphase"></div>
+						<div class="guide-item d-u2"></div>
+						<div class="guide-item d-swap"></div>
+						<div class="guide-item d-measure"></div>
+						<div class="guide-item d-end"></div>
+						<div class="guide-item d-oracle"></div>
 					</div>
 				</div>
 			</div>

--- a/static/index.html
+++ b/static/index.html
@@ -39,62 +39,62 @@
 				  	 		<div id="reference-content">
 					  	 		<h3>reference</h3>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-qnot">&nbsp;?</div><div class="reference-item">
 					  	 				qnot <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-cnot">&nbsp;?</div><div class="reference-item">
 					  	 				cnot <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-srn">&nbsp;?</div><div class="reference-item">
 					  	 				srn <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-nand">&nbsp;?</div><div class="reference-item">
 					  	 				nand <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-hadamard">&nbsp;?</div><div class="reference-item">
 					  	 				hadamard <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-utheta">&nbsp;?</div><div class="reference-item">
 					  	 				utheta <i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-cphase">&nbsp;?</div><div class="reference-item">
 					  	 				cphase <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-u2">&nbsp;?</div><div class="reference-item">
 					  	 				u2 <i class="icon icon-qubit"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i><i class="icon icon-angle"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-swap">&nbsp;?</div><div class="reference-item">
 					  	 				swap <i class="icon icon-qubit"></i><i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-measure">&nbsp;?</div><div class="reference-item">
 					  	 				measure <i class="icon icon-qubit"></i>
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-end">&nbsp;?</div><div class="reference-item">
 					  	 				end
 					  	 			</div>
 					  	 		</div>
 					  	 		<div class="reference-line">
-					  	 			<div class="button reference-button">&nbsp;?</div><div class="reference-item">
+					  	 			<div class="button reference-button" data-target="#d-oracle">&nbsp;?</div><div class="reference-item">
 					  	 				oracle <i class="icon icon-qubit"></i>...
 					  	 			</div>
 					  	 		</div>

--- a/static/setup.js
+++ b/static/setup.js
@@ -40,14 +40,14 @@ $(document).ready(function() {
 		$("#hidden-file-input").click();
 	});
 
-	$("#export").on('click', exportProgram);
+	$("#export").on("click", exportProgram);
 
 	// --- Open guide content --- \\
 	$(".guide-link").click(function() {
 		var $this = $(this);
 		$guideMenu.addClass("hidden");
 		$guideDetail.removeClass("hidden");
-		$("#guide-item-title").text($this.text());
+		$(".guide-item-title").text($this.text());
 		$($this.data("target")).addClass("current");
 	});
 	
@@ -57,7 +57,7 @@ $(document).ready(function() {
 		var $current = $guideDetail.addClass("hidden").children(".current");
 		setTimeout(function() {$current.removeClass("current");}, 450)
 	});
-	
+
 	// --- Toggle visibility of reference drawer --- \\
 	$("#reference-handle").click(function() {
 		var $this = $(this);
@@ -91,6 +91,12 @@ $(document).ready(function() {
 				$dragged.css({"top": event.pageY - diffY, "left": event.pageX - diffX});
 			})
 	});
+	
+	// --- Open guide documentation content with ref "?" button --- \\
+	$(".reference-button").on("click", function () {
+		// We already have something to handle this. Use it.
+		$(".guide-item, " + $(this).data("target")).trigger("click");
+	})
 
 	// --- Set editor to example text --- \\
 	$(".example").on("click", function (evt) {
@@ -184,7 +190,7 @@ $(document).ready(function() {
 	}
 
 	// *** GUIDE HTML *** \\
-	$("#l-start").html("Welcome to qromp, a quantum programming environment designed to help you learn all about stuff..."
+	$(".guide-item.l-start").html("Welcome to qromp, a quantum programming environment designed to help you learn all about stuff..."
 		+ "\n<div class='example-list'>"
 		+ "\nClick on an example (feature incomplete):"
 		+ "\n<ul>"
@@ -204,24 +210,24 @@ $(document).ready(function() {
 		+ "\n</div>"
 	);  // end #l-start.html
 
-	$("#l-quant-comp").html("Stuff about quantum computers");  // end #l-quant-comp.html
-	$("#l-qubits").html("Stuff about qubits"); // end #l-qubits.html
-	$("#l-gates").html("Stuff about gates"); // end #l-gates.html
-	$("#l-oracles").html("Stuff about oracles"); // end #l-oracles.html
-	$("#l-grovers").html("Stuff about grovers"); // end #l-grovers.html
-	$("#e-deutsch-jozsa").html("Stuff about deutsch-jozsa"); // end #e-deutsch-jozsa.html
-	$("#e-grovers").html("Stuff about grovers"); // end #e-grovers.html
-	$("#e-shors").html("Stuff about shors"); // end #e-shors.html
-	$("#d-qnot").html("Stuff about qnot"); // end #d-qnot.html
-	$("#d-cnot").html("Stuff about cnot"); // end #d-cnot.html
-	$("#d-srn").html("Stuff about srn"); // end #d-srn.html
-	$("#d-nand").html("Stuff about nand"); // end #d-nand.html
-	$("#d-hadamard").html("Stuff about hadamard"); // end #d-hadamard.html
-	$("#d-utheta").html("Stuff about utheta"); // end #d-utheta.html
-	$("#d-cphase").html("Stuff about cphase"); // end #d-cphase.html
-	$("#d-u2").html("Stuff about u2"); // end #d-u2.html
-	$("#d-swap").html("Stuff about swap"); // end #d-swap.html
-	$("#d-measure").html("Stuff about measure"); // end #d-measure.html
-	$("#d-end").html("Stuff about end"); // end #d-end.html
-	$("#d-oracle").html("Stuff about oracle"); // end #d-oracle.html
+	$(".guide-item.l-quantcomp").html("Stuff about quantum computers");  // end .l-quantcomp.html
+	$(".guide-item.l-qubits").html("Stuff about qubits"); // end .l-qubits.html
+	$(".guide-item.l-gates").html("Stuff about gates"); // end .l-gates.html
+	$(".guide-item.l-oracles").html("Stuff about oracles"); // end .l-oracles.html
+	$(".guide-item.l-grovers").html("Stuff about grovers"); // end .l-grovers.html
+	$(".guide-item.e-deutschjozsa").html("Stuff about deutsch-jozsa"); // end .e-deutschjozsa.html
+	$(".guide-item.e-grovers").html("Stuff about grovers"); // end .e-grovers.html
+	$(".guide-item.e-shors").html("Stuff about shors"); // end .e-shors.html
+	$(".guide-item.d-qnot").html("Stuff about qnot"); // end .d-qnot.html
+	$(".guide-item.d-cnot").html("Stuff about cnot"); // end .d-cnot.html
+	$(".guide-item.d-srn").html("Stuff about srn"); // end .d-srn.html
+	$(".guide-item.d-nand").html("Stuff about nand"); // end .d-nand.html
+	$(".guide-item.d-hadamard").html("Stuff about hadamard"); // end .d-hadamard.html
+	$(".guide-item.d-utheta").html("Stuff about utheta"); // end .d-utheta.html
+	$(".guide-item.d-cphase").html("Stuff about cphase"); // end .d-cphase.html
+	$(".guide-item.d-u2").html("Stuff about u2"); // end .d-u2.html
+	$(".guide-item.d-swap").html("Stuff about swap"); // end .d-swap.html
+	$(".guide-item.d-measure").html("Stuff about measure"); // end .d-measure.html
+	$(".guide-item.d-end").html("Stuff about end"); // end .d-end.html
+	$(".guide-item.d-oracle").html("Stuff about oracle"); // end .d-oracle.html
 });

--- a/static/setup.js
+++ b/static/setup.js
@@ -45,6 +45,10 @@ $(document).ready(function() {
 	// --- Open guide content --- \\
 	$(".guide-link").click(function() {
 		var $this = $(this);
+		// This means the text won't disappear when guide item is closed
+		// (won't need a delay before removing) and yet will have the
+		// correct text
+		$(".guide-item").removeClass("current");
 		$guideMenu.addClass("hidden");
 		$guideDetail.removeClass("hidden");
 		$(".guide-item-title").text($this.text());
@@ -55,7 +59,7 @@ $(document).ready(function() {
 	$("#guide-back").click(function() {
 		$guideMenu.removeClass("hidden");
 		var $current = $guideDetail.addClass("hidden").children(".current");
-		setTimeout(function() {$current.removeClass("current");}, 450)
+		// setTimeout(function() {$current.removeClass("current");}, 450)
 	});
 
 	// --- Toggle visibility of reference drawer --- \\


### PR DESCRIPTION
Clicking on a question mark basically triggers clicking on the documentation list item itself.

Had to change id's to classes and give them to list items as well as guide details.

Had to put the removal of the "current" class in the click that opens the detail as opposed to the click that closed it. It's probably cleaner this way anyway, no setTimeout() is needed now, though I simply commented it out - I wanted to show what happened. I also made comments to that effect. Those can both be removed.

Also changed the title of the details guide section to "lessons, examples, & documentation"
