### PR TITLE
Event delegation for the win! Fixes examples not working

### DIFF
--- a/static/setup.js
+++ b/static/setup.js
@@ -103,7 +103,7 @@ $(document).ready(function() {
 	})
 
 	// --- Set editor to example text --- \\
-	$(".example").on("click", function (evt) {
+	$(document).on("click", ".example", function (evt) {
 		editor.getSession().setValue($(this).text());
 	});
 


### PR DESCRIPTION
Since these are being put in dynamically now, they just need some event delegation. I thought .on("click") was enough, but obviously forgot everything about event delegation.
